### PR TITLE
timestamp

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #include "parameter/parameter_msgpack.h"
 #include <string.h>
 #include <math.h>
+#include "timestamp/timestamp_stm32.h"
 #include "bootloader_config.h"
 #include "uavcan_node.h"
 
@@ -172,6 +173,10 @@ int main(void) {
     if (!config_get(&config)) {
         chSysHalt("invalid config");
     }
+
+    chSysLock();
+    timestamp_stm32_init();
+    chSysUnlock();
 
     sdStart(&SD3, NULL);
     ch_stdout = (BaseSequentialStream*)&SD3;

--- a/src/timestamp_stm32_settings.h
+++ b/src/timestamp_stm32_settings.h
@@ -1,0 +1,32 @@
+#ifndef TIMESTAMP_STM32_SETTINGS_H
+#define TIMESTAMP_STM32_SETTINGS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <ch.h>
+
+// settings
+#define TIMESTAMP_TIMER TIM7
+#define TIMER_REG       STM32_TIM7
+#define TIMER_IRQ_NAME  STM32_TIM7_HANDLER
+#define RCC_EN()        rccEnableTIM7(FALSE)
+#define RCC_RESET()     rccResetTIM7()
+#define NVIC_NB         STM32_TIM7_NUMBER
+
+#define COUNTER_MAX     0xffff
+
+// CK_CNT = CK_INT / (PSC[15:0] + 1)
+#if STM32_PPRE1 == STM32_PPRE1_DIV1
+#define PRESCALER       (STM32_PCLK1/1000000 - 1)
+#else
+#define PRESCALER       (2*STM32_PCLK1/1000000 - 1)
+#endif
+#define INTERRUPT_PRIO  5
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TIMESTAMP_STM32_SETTINGS_H */


### PR DESCRIPTION
Note: timestamp_get() should not be used from interrupts with higher priority than the timestamp timer interrupt priority.
